### PR TITLE
Fix response after audio upload

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -50,12 +50,11 @@
           body: formData,
         });
 
-        const texto = await res.text();
-        respuestaDiv.textContent = `Estado: ${res.status}\n\nRespuesta:\n${texto}`;
+        const json = await res.json();
+        respuestaDiv.textContent = `Estado: ${res.status}\n\nRespuesta:\n${JSON.stringify(json, null, 2)}`;
 
         // Si tiene un ID, asumimos que fue exitoso
-        if (res.status === 201 && texto.includes('"id"')) {
-          const json = JSON.parse(texto);
+        if (res.status === 201 && json.id) {
           const id = json.id;
 
           // Reproducir automáticamente el audio cargado

--- a/src/routers/discriminacion.js
+++ b/src/routers/discriminacion.js
@@ -14,8 +14,8 @@ router.post('/subir', upload.single('audio'), async (req, res) => {
       tipo: req.file.mimetype,
     });
 
-    await nuevoAudio.save();
-    res.status(201).send('Audio guardado exitosamente');
+    const guardado = await nuevoAudio.save();
+    res.status(201).json({ id: guardado._id, mensaje: 'Audio guardado exitosamente' });
   } catch (err) {
     console.error(err);
     res.status(500).send('Error al guardar el audio');


### PR DESCRIPTION
## Summary
- return the saved audio's ID from `/subir`
- handle JSON response in the front-end upload script

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6843998df8c88324a305a8eb54786ade